### PR TITLE
Updating packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,18 @@
 	"author": "Mike Kornelson <mike@durbn.net>",
 	"license": "MIT",
 	"devDependencies": {
-		"babel-core": "^6.24.1",
-		"babel-loader": "^6.4.1",
+		"babel-core": "^6.25.0",
+		"babel-loader": "^7.0.0",
 		"babel-preset-es2015": "^6.24.1",
 		"babel-preset-stage-1": "^6.24.1",
-		"chai": "^3.5.0",
+		"chai": "^4.0.2",
 		"ink-docstrap": "^1.3.0",
 		"jsdoc": "^3.4.3",
 		"jsdoc-babel": "^0.3.0",
 		"jsdoc-to-markdown": "^3.0.0",
-		"mocha": "^3.2.0",
-		"webpack": "^2.4.1",
-		"webpack-node-externals": "^1.5.4"
+		"mocha": "^3.4.2",
+		"webpack": "^2.6.1",
+		"webpack-node-externals": "^1.6.0"
 	},
 	"dependencies": {
 		"escape-string-regexp": "^1.0.5",


### PR DESCRIPTION
babel-loader  ^6.4.1  →  ^7.0.0 
 chai          ^3.5.0  →  ^4.0.2 
 babel-core              ^6.24.1  →  ^6.25.0 
 mocha                    ^3.2.0  →   ^3.4.2 
 webpack                  ^2.4.1  →   ^2.6.1 
 webpack-node-externals   ^1.5.4  →   ^1.6.0